### PR TITLE
fix: handle string \n in command

### DIFF
--- a/server/src/commands/read_command.c
+++ b/server/src/commands/read_command.c
@@ -19,8 +19,8 @@ char *read_data_client(client_t *tmp)
         return NULL;
     while (read(tmp->_fd, buffer, 1) > 0) {
         cmd[n] = buffer[0];
-        if (cmd[n] == '\n' && n != 0
-        && cmd[n -1] == '\r')
+        if ((cmd[n] == '\n' && n != 0 && cmd[n -1] == '\r') ||
+            (cmd[n] == 'n' && n != 0 && cmd[n -1] == '\\'))
             break;
         n++;
     }


### PR DESCRIPTION
fixed the handle of \n in read command